### PR TITLE
doc: Improve docs

### DIFF
--- a/src/endpoint/document.rs
+++ b/src/endpoint/document.rs
@@ -126,7 +126,7 @@ impl<'a> UploadDocumentRequester<'a> {
             } else {
                 part = part.file_name(file_path.file_name().expect(
                     "No extension found for this file, and no filename given, cannot make request",
-                ).to_str().expect("no a valid UTF-8 filepath!").to_string());
+                ).to_str().expect("not a valid UTF-8 filepath!").to_string());
             }
 
             form = form.part("file", part);
@@ -172,28 +172,29 @@ impl<'a> IntoFuture for &mut UploadDocumentRequester<'a> {
 
 impl DeepLApi {
     /// Upload document to DeepL API server, return [`UploadDocumentResp`] for
-    /// quering the translation status and to download the translated document once
+    /// querying the translation status and to download the translated document once
     /// translation is complete.
     ///
     /// # Example
     ///
     /// ```rust
-    /// use deepl::DeepLApi
+    /// use deepl::DeepLApi;
     ///
-    /// let api = DeepLApi::with(&key).new();
+    /// let key = std::env::var("DEEPL_API_KEY").unwrap();
+    /// let deepl = DeepLApi::with(&key).new();
     ///
     /// // Upload the file to DeepL
     /// let filepath = std::path::PathBuf::from("./hamlet.txt");
-    /// let response = api.upload_document(&filepath, Lang::ZH)
-    ///         .source_lang(Lang::EN_GB)
-    ///         .filename("Hamlet.txt")
+    /// let response = deepl.upload_document(&filepath, Lang::ZH)
+    ///         .source_lang(Lang::EN)
+    ///         .filename("Hamlet.txt".to_string())
     ///         .formality(Formality::Default)
-    ///         .glossary_id("def3a26b-3e84-45b3-84ae-0c0aaf3525f7")
+    ///         .glossary_id("def3a26b-3e84-45b3-84ae-0c0aaf3525f7".to_string())
     ///         .await
     ///         .unwrap();
     /// ```
     ///
-    /// Read the example `upload_document` in repository for detail usage
+    /// Read the example `upload_document` in repository for detailed usage
     pub fn upload_document(
         &self,
         fp: impl Into<std::path::PathBuf>,

--- a/src/endpoint/mod.rs
+++ b/src/endpoint/mod.rs
@@ -83,6 +83,7 @@ macro_rules! impl_requester {
     };
 }
 
+/// Formality preference for translation
 #[derive(Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum Formality {

--- a/src/endpoint/translate.rs
+++ b/src/endpoint/translate.rs
@@ -236,7 +236,6 @@ impl DeepLApi {
     /// let deepl = DeepLApi::with(&key).new();
     ///
     /// let response = deepl.translate_text("Hello World", Lang::ZH).await.unwrap();
-    ///
     /// assert!(!response.translations.is_empty());
     /// ```
     ///
@@ -245,9 +244,11 @@ impl DeepLApi {
     /// ```rust
     /// use deepl::{DeepLApi, Lang};
     ///
-    /// let api = DeepLApi::new("YOUR AUTH KEY", false);
+    /// let key = std::env::var("DEEPL_API_KEY").unwrap();
+    /// let deepl = DeepLApi::with(&key).new();
+    ///
     /// let str = "Hello World <keep>This will stay exactly the way it was</keep>";
-    /// let response = api
+    /// let response = deepl
     ///     .translate_text(str, Lang::DE)
     ///     .source_lang(Lang::EN)
     ///     .ignore_tags(vec!["keep".to_owned()])

--- a/src/endpoint/usage.rs
+++ b/src/endpoint/usage.rs
@@ -15,10 +15,11 @@ impl DeepLApi {
     /// # Example
     ///
     /// ```rust
-    /// use deepl::DeepLApi
+    /// use deepl::DeepLApi;
     ///
-    /// let api = DeepLApi::new("Your DeepL Token", false);
-    /// let response = api.get_usage().await.unwrap();
+    /// let key = std::env::var("DEEPL_API_KEY").unwrap();
+    /// let deepl = DeepLApi::with(&key).new();
+    /// let response = deepl.get_usage().await.unwrap();
     ///
     /// assert_ne!(response.character_count, 0);
     /// ```

--- a/src/lang.rs
+++ b/src/lang.rs
@@ -17,6 +17,7 @@ macro_rules! generate_langs {
         )+
     ) => {
         paste! {
+            /// Languages
             #[allow(non_camel_case_types)]
             #[derive(Clone, Debug, PartialEq, Eq, Serialize)]
             #[serde(rename_all = "SCREAMING-KEBAB-CASE")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,14 +1,16 @@
 //! # deepl-rs
 //!
-//! Deepl-rs is a simple library for making request to the DeepL API endpoint easier.
-//! And it also providing types wrapping to guarantee runtime safety.
+//! Deepl-rs is a simple library for making requests to the DeepL API endpoint easier.
+//! And it also provides types wrapping to guarantee runtime safety.
 //!
-//! This is still a **WORK IN PROGRESS** library, please open a issue on GitHub to tell
-//! me what feature you want. Also breaking changes will also be released frequently.
+//! This is still a **WORK IN PROGRESS** library, please open an issue on GitHub to request
+//! features. Be aware breaking changes will be released frequently.
 //!
 //! # Usage
 //!
 //! ```rust
+//! use deepl::DeepLApi;
+//!
 //! let key = std::env::var("DEEPL_API_KEY").unwrap();
 //! let api = DeepLApi::with(&key).new();
 //! let response = api.translate_text("Hello World", Lang::ZH).await.unwrap();
@@ -16,7 +18,7 @@
 //! assert!(!response.translations.is_empty());
 //! ```
 //!
-//! See [`DeepLApi`] for detail usage.
+//! See [`DeepLApi`] for detailed usage.
 //!
 //! # License
 //!
@@ -40,7 +42,7 @@ pub use reqwest;
 //-
 
 /// A struct that contains necessary data for runtime. Data is stored in
-/// [`Arc`], so it is cheap to clone in your Apps code.
+/// [`Arc`], so it is cheap to clone in your App's code.
 ///
 /// # Example
 ///
@@ -55,7 +57,7 @@ pub use reqwest;
 ///         .build()
 ///         .unwrap();
 ///
-/// // use the pro version API, and custom the client with
+/// // use the pro version API, and a custom client with
 /// // 30 secs timeout
 /// let deepl = DeepLApi::with("Your DeepL Key")
 ///                 .is_pro(true)


### PR DESCRIPTION
* minor typo fixes and suggestions
* add missing docs for `Formality` and `Lang` enums
* fix doc examples to match the current api

Since doc tests don't easily allow async fn, the examples were temporarily replicated as tokio unit tests to ensure they pass. These changes don't touch any internal logic, so it should be purely cosmetic. However I did successfully set up a nix environment as mentioned in the README for the sake of testing. Any feedback appreciated!