### PR TITLE
Add languages endpoint

### DIFF
--- a/src/endpoint/languages.rs
+++ b/src/endpoint/languages.rs
@@ -1,0 +1,74 @@
+use super::{Error, Result};
+use crate::DeepLApi;
+use serde::Deserialize;
+
+/// Information about a supported language
+#[derive(Deserialize)]
+pub struct LangInfo {
+    /// Language code
+    pub language: String,
+    /// Language name
+    pub name: String,
+    /// Denotes a target language supports formality
+    pub supports_formality: Option<bool>,
+}
+
+/// Language type used to request supported languages
+#[derive(Debug)]
+pub enum LangType {
+    /// Source language
+    Source,
+    /// Target language
+    Target,
+}
+
+impl AsRef<str> for LangType {
+    fn as_ref(&self) -> &str {
+        match self {
+            Self::Source => "source",
+            Self::Target => "target",
+        }
+    }
+}
+
+impl DeepLApi {
+    ///
+    /// Retrieve supported languages for a given [`LangType`]
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// let target_langs = deepl.languages(LangType::Target).await.unwrap();
+    /// assert!(!target_langs.is_empty());
+    ///
+    /// let lang = target_langs.first().unwrap();
+    /// println!("{}", lang.language); // BG
+    /// println!("{}", lang.name); // Bulgarian
+    /// ```
+    pub async fn languages(&self, lang_type: LangType) -> Result<Vec<LangInfo>> {
+        let q = vec![("type", lang_type.as_ref())];
+
+        let resp = self
+            .get(self.get_endpoint("languages"))
+            .query(&q)
+            .send()
+            .await
+            .map_err(|err| Error::RequestFail(err.to_string()))?;
+
+        if !resp.status().is_success() {
+            return super::extract_deepl_error(resp).await;
+        }
+
+        resp.json().await.map_err(|err| {
+            Error::InvalidResponse(format!("convert json bytes to Rust type: {err}"))
+        })
+    }
+}
+
+#[tokio::test]
+async fn test_get_languages() {
+    let deepl = DeepLApi::with(&std::env::var("DEEPL_API_KEY").unwrap()).new();
+
+    let langs = deepl.languages(LangType::Target).await.unwrap();
+    assert!(!langs.is_empty());
+}

--- a/src/endpoint/mod.rs
+++ b/src/endpoint/mod.rs
@@ -3,6 +3,7 @@ use std::{future::Future, pin::Pin};
 use thiserror::Error;
 
 pub mod document;
+pub mod languages;
 pub mod translate;
 pub mod usage;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,6 +33,7 @@ use std::sync::Arc;
 //- Type Re-exporting
 pub use endpoint::{
     document::{DocumentStatusResp, DocumentTranslateStatus, UploadDocumentResp},
+    languages::{LangInfo, LangType},
     translate::{TagHandling, TranslateTextResp},
     usage::UsageResponse,
     Error, Formality,
@@ -87,6 +88,13 @@ impl DeepLApi {
         self.inner
             .client
             .post(url)
+            .header("Authorization", &self.inner.key)
+    }
+
+    fn get(&self, url: reqwest::Url) -> reqwest::RequestBuilder {
+        self.inner
+            .client
+            .get(url)
             .header("Authorization", &self.inner.key)
     }
 


### PR DESCRIPTION
This change adds the GET [/languages](https://www.deepl.com/docs-api/general/get-languages) endpoint.

A new unit test `test_generate_langs` ensures that all languages retrieved from `api/v2/languages` are adequately structured by enum `Lang`.

Note: not all tests passing for reasons discussed in #17 