### PR TITLE
Export LangConvertError

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,7 +38,7 @@ pub use endpoint::{
     usage::UsageResponse,
     Error, Formality,
 };
-pub use lang::Lang;
+pub use lang::{Lang, LangConvertError};
 pub use reqwest;
 //-
 


### PR DESCRIPTION
Hi,

I hope this message finds you well. I recently encountered an issue while using the try_from() method in the Lang enum from the deepl crate. It appears that the error type LangConvertError is not currently exported with the public interface.

To address this, I propose a simple modification to include the export of LangConvertError in the try_from() method. This change would enhance the crate's usability by allowing users to handle conversion errors more effectively.

Please let me know if you have any feedback or if there's anything else I can do to help with this contribution.

Thank you for your time and consideration.