### PR TITLE
Automatically switch to correct endpoint with pro key.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -142,7 +142,7 @@ impl DeepLApiBuilder {
     /// Create a new instance of the DeepLApi
     pub fn new(&self) -> DeepLApi {
         let client = self.client.clone().unwrap_or_else(reqwest::Client::new);
-        let endpoint = if self.is_pro {
+        let endpoint = if self.is_pro || !self.key.ends_with(":fx") {
             "https://api.deepl.com/v2/"
         } else {
             "https://api-free.deepl.com/v2/"


### PR DESCRIPTION
Tokens that are for the Free API Always end with ":fx", so we can use this to automatically swap to the correct version, preventing the user from manually set this