### PR TITLE
Use json to build translate form body

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -152,7 +152,7 @@ checksum = "22ec99545bb0ed0ea7bb9b8e1e9122ea386ff8a48c0922e43f36d45ab09e0e80"
 
 [[package]]
 name = "deepl"
-version = "0.6.3"
+version = "0.6.4"
 dependencies = [
  "docx-rs",
  "paste",

--- a/src/endpoint/mod.rs
+++ b/src/endpoint/mod.rs
@@ -59,7 +59,9 @@ macro_rules! impl_requester {
 
         paste! {
             #[doc = "Builder type for `" $name "`"]
+            #[derive(Debug, serde::Serialize)]
             pub struct $name<'a> {
+                #[serde(skip)]
                 client: &'a DeepLApi,
 
                 $($must_field: $must_type,)+
@@ -88,7 +90,7 @@ macro_rules! impl_requester {
 }
 
 /// Formality preference for translation
-#[derive(Serialize)]
+#[derive(Debug, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum Formality {
     Default,

--- a/src/lang.rs
+++ b/src/lang.rs
@@ -22,10 +22,10 @@ macro_rules! generate_langs {
             /// Languages
             #[allow(non_camel_case_types)]
             #[derive(Clone, Debug, Hash, PartialEq, Eq, Serialize)]
-            #[serde(rename_all = "SCREAMING-KEBAB-CASE")]
             pub enum Lang {
                 $(
                     #[doc = $desc]
+                    #[serde(rename = $code)]
                     [<$code>],
                 )+
             }


### PR DESCRIPTION
Hi @Avimitin, wondering if you could comment on this approach to sending a json body. To make it work I did the following

* derive `Serialize` for `TranslateRequester`
* change field `text` in translate requester to have type `Vec<String>`
* fix the serde "rename" attribute for `Lang` (otherwise SCREAMING-KEBAB case wants to hyphenate every letter)

fixes #25 