### PR TITLE
[test] Don't assert `character_count` in `test_usage`

### DIFF
--- a/src/endpoint/translate.rs
+++ b/src/endpoint/translate.rs
@@ -263,7 +263,7 @@ async fn test_advanced_translator_html() {
 async fn test_formality() {
     let api = DeepLApi::with(&std::env::var("DEEPL_API_KEY").unwrap()).new();
 
-    // sends and returns a formality
+    // can specify a formality
     let text = "How are you?";
     let src = Lang::EN;
     let trg = Lang::ES;
@@ -275,9 +275,7 @@ async fn test_formality() {
         .formality(more)
         .await
         .unwrap();
-
     assert!(!response.translations.is_empty());
-    assert_eq!(response.translations[0].text, "¿Cómo está?");
 
     // response ok, despite target lang not supporting formality
     let text = "¿Cómo estás?";
@@ -291,7 +289,5 @@ async fn test_formality() {
         .formality(less)
         .await
         .unwrap();
-
     assert!(!response.translations.is_empty());
-    assert_eq!(response.translations[0].text, "How are you doing?");
 }

--- a/src/endpoint/usage.rs
+++ b/src/endpoint/usage.rs
@@ -48,5 +48,5 @@ async fn test_usage() {
     let api = DeepLApi::with(&key).new();
     let response = api.get_usage().await.unwrap();
 
-    assert_ne!(response.character_count, 0);
+    assert_ne!(response.character_limit, 0);
 }


### PR DESCRIPTION
which may fail if the API account has no usage for the current period. Instead assert a non-zero `character_limit`.

Additionally, clean up `test_formality` to no longer assert the content of text translation, as we don't guarantee consistency across API calls