### PR TITLE
Let's support the selection of model

### DIFF
--- a/src/endpoint/translate.rs
+++ b/src/endpoint/translate.rs
@@ -83,9 +83,7 @@ pub enum TagHandling {
     Html,
 }
 
-///
 /// Sets the language model to use: allows to choose an improved "next-gen" model
-///
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum ModelType {
@@ -252,10 +250,10 @@ async fn test_advanced_translate() {
 
 #[tokio::test]
 async fn test_models() {
+    let api = DeepLApi::with(&std::env::var("DEEPL_API_KEY").unwrap()).new();
+
     // whatever model is used, the translation should happen, and it can differ slightly
     for model_type in [ModelType::LatencyOptimized, ModelType::QualityOptimized, ModelType::QualityOptimized] {
-        let api = DeepLApi::with(&std::env::var("DEEPL_API_KEY").unwrap()).new();
-
         let response = api
             .translate_text("No te muevas, pringao", Lang::EN)
             .source_lang(Lang::ES)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,7 +35,7 @@ pub use endpoint::{
     document::{DocumentStatusResp, DocumentTranslateStatus, UploadDocumentResp},
     glossary,
     languages::{LangInfo, LangType},
-    translate::{TagHandling, TranslateTextResp},
+    translate::{TagHandling, TranslateTextResp, ModelType},
     usage::UsageResponse,
     Error, Formality,
 };


### PR DESCRIPTION
Sometimes it's needed to choose the _next-gen_ model, because the classic model just leaves certain convoluted phrases untranslated, or translated oddly.
