### PR TITLE
Document ToTranslatable

### DIFF
--- a/src/endpoint/translate.rs
+++ b/src/endpoint/translate.rs
@@ -163,6 +163,7 @@ impl<'a> TranslateRequester<'a> {
     }
 }
 
+/// A value that can be used as text input for the api/v2/translate endpoint
 pub trait ToTranslatable {
     fn to_translatable(&self) -> Vec<String>;
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,7 @@ pub use endpoint::{
     document::{DocumentStatusResp, DocumentTranslateStatus, UploadDocumentResp},
     glossary,
     languages::{LangInfo, LangType},
-    translate::{ModelType, TagHandling, TranslateTextResp},
+    translate::{ModelType, TagHandling, ToTranslatable, TranslateTextResp},
     usage::UsageResponse,
     Error, Formality,
 };


### PR DESCRIPTION
I was a bit confused to find undocumented traits in translate_text, so now the trait is re-exported and properly documented.