### PR TITLE
Fix: Export PreserveFormatting and SplitSentences in lib.rs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,7 @@ pub use endpoint::{
     document::{DocumentStatusResp, DocumentTranslateStatus, UploadDocumentResp},
     glossary,
     languages::{LangInfo, LangType},
-    translate::{ModelType, TagHandling, ToTranslatable, TranslateTextResp},
+    translate::{ModelType, TagHandling, ToTranslatable, TranslateTextResp, PreserveFormatting, SplitSentences},
     usage::UsageResponse,
     Error, Formality,
 };


### PR DESCRIPTION
This adds the PreserveFormatting and SplitSentences enums to lib.rs, making them available to use as they currently are not accessible when setting your options for the translate module.