### PR TITLE
fix: helpful error if decoding fails

### DIFF
--- a/src/endpoint/languages.rs
+++ b/src/endpoint/languages.rs
@@ -106,7 +106,9 @@ async fn test_missing_language_error() {
     use crate::Lang;
     let deepl = DeepLApi::with(&std::env::var("DEEPL_API_KEY").unwrap()).new();
 
-    let res = deepl.translate_text("kini angay ilhon nga cebuano", Lang::EN).await;
+    let res = deepl
+        .translate_text("kini angay ilhon nga cebuano", Lang::EN)
+        .await;
 
     let error = format!("{}", res.err().unwrap());
     println!("Error is:\n{error}");

--- a/src/endpoint/languages.rs
+++ b/src/endpoint/languages.rs
@@ -100,3 +100,15 @@ async fn test_generate_langs() {
         })
         .collect();
 }
+
+#[tokio::test]
+async fn test_missing_language_error() {
+    use crate::Lang;
+    let deepl = DeepLApi::with(&std::env::var("DEEPL_API_KEY").unwrap()).new();
+
+    let res = deepl.translate_text("kini angay ilhon nga cebuano", Lang::EN).await;
+
+    let error = format!("{}", res.err().unwrap());
+    println!("Error is:\n{error}");
+    assert!(error.contains("CEB"));
+}

--- a/src/endpoint/translate.rs
+++ b/src/endpoint/translate.rs
@@ -1,3 +1,4 @@
+use std::error::Error as StdError;
 use std::future::IntoFuture;
 
 use crate::{
@@ -153,6 +154,14 @@ impl<'a> TranslateRequester<'a> {
             }
 
             let response: TranslateTextResp = response.json().await.map_err(|err| {
+                if err.is_decode() {
+                    // If serialization failed, useful information is hidden in the source
+                    if let Some(source) = err.source() {
+                        return Error::InvalidResponse(format!(
+                            "convert json bytes to Rust type: {source}"
+                        ));
+                    }
+                }
                 Error::InvalidResponse(format!("convert json bytes to Rust type: {err}"))
             })?;
 

--- a/src/lang.rs
+++ b/src/lang.rs
@@ -146,7 +146,7 @@ impl<'de> Deserialize<'de> for Lang {
 
         let lang = Lang::try_from(&lang).map_err(|_| {
             serde::de::Error::custom(
-                format!("invalid language code {lang}. This is an internal issue with the lib, please open issue")
+                format!("invalid language code {lang}. This is an internal issue with the lib, please open an issue!")
             )
         })?;
 


### PR DESCRIPTION
ref #47

the error message already existed, but is being wrapped and subsequently discarded by `reqwest::Error`.

```
---- endpoint::languages::test_missing_language_error stdout ----
Error is:
invalid response: convert json bytes to Rust type: invalid language code CEB. This is an internal issue with the lib, please open an issue! at line 1 column 98
```