### PR TITLE
lang: add HR (Croatian), SR (Serbian), BS (Bosnian) variants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+- Add `HR` (Croatian), `SR` (Serbian), and `BS` (Bosnian) variants to `Lang`.
+  These are supported by DeepL's HTTP API as both source and target languages.
+
 ## v0.7.3 - 2025-12-01
 
 - Allow `String` and `Vec<String>` as translate API input

--- a/src/lang.rs
+++ b/src/lang.rs
@@ -97,6 +97,7 @@ macro_rules! generate_langs {
 generate_langs! {
     ("AR",    "Arabic");
     ("BG",    "Bulgarian");
+    ("BS",    "Bosnian");
     ("CS",    "Czech");
     ("DA",    "Danish");
     ("DE",    "German");
@@ -110,6 +111,7 @@ generate_langs! {
     ("FI",    "Finnish");
     ("FR",    "French");
     ("HE",    "Hebrew");
+    ("HR",    "Croatian");
     ("HU",    "Hungarian");
     ("ID",    "Indonesian");
     ("IT",    "Italian");
@@ -127,6 +129,7 @@ generate_langs! {
     ("RU",    "Russian");
     ("SK",    "Slovak");
     ("SL",    "Slovenian");
+    ("SR",    "Serbian");
     ("SV",    "Swedish");
     ("TH",    "Thai");
     ("TR",    "Turkish");


### PR DESCRIPTION
DeepL's HTTP API supports these three languages as both source and target languages, but they were missing from the Lang enum. This means Lang::try_from("HR" | "SR" | "BS") currently returns Err and the test_generate_langs integration test (which iterates the live DeepL languages endpoint) fails to convert them.

These languages do not support formality and are not on DeepL's glossary-supported list, so no changes are needed in those code paths.