### PR TITLE
chore: bump version to v0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 ## Unreleased
 
+## v0.8.0 - 2026-05-20
+
+- Sync `Lang` enum with current DeepL API: expanded from 42 to 108 supported languages.
+  This includes `AF` (Afrikaans), `AN` (Aragonese), `AS` (Assamese), `AY` (Aymara),
+  `AZ` (Azerbaijani), `BA` (Bashkir), `BE` (Belarusian), `BN` (Bengali), `BR` (Breton),
+  `CA` (Catalan), `CY` (Welsh), `DE-DE` (German Germany), `EO` (Esperanto),
+  `ES-419` (Spanish Latin America), `EU` (Basque), `FA` (Persian), `FR-FR` (French France),
+  `GA` (Irish), `GL` (Galician), `GN` (Guarani), `GU` (Gujarati), `HA` (Hausa),
+  `HI` (Hindi), `HT` (Haitian Creole), `HY` (Armenian), `IG` (Igbo), `IS` (Icelandic),
+  `JV` (Javanese), `KA` (Georgian), `KK` (Kazakh), `KY` (Kyrgyz), `LA` (Latin),
+  `LB` (Luxembourgish), `LN` (Lingala), `MG` (Malagasy), `MI` (Maori), `MK` (Macedonian),
+  `ML` (Malayalam), `MN` (Mongolian), `MR` (Marathi), `MS` (Malay), `MT` (Maltese),
+  `MY` (Burmese), `NE` (Nepali), `OC` (Occitan), `OM` (Oromo), `PA` (Punjabi),
+  `PS` (Pashto), `PT-PT` (Portuguese European), `QU` (Quechua), `SA` (Sanskrit),
+  `SQ` (Albanian), `ST` (Sesotho), `SU` (Sundanese), `SW` (Swahili), `TA` (Tamil),
+  `TE` (Telugu), `TG` (Tajik), `TK` (Turkmen), `TL` (Tagalog), `TN` (Tswana),
+  `TS` (Tsonga), `TT` (Tatar), `UR` (Urdu), `UZ` (Uzbek), `WO` (Wolof), `XH` (Xhosa),
+  `YI` (Yiddish), `ZU` (Zulu), and more.
 - Add `HR` (Croatian), `SR` (Serbian), and `BS` (Bosnian) variants to `Lang`.
   These are supported by DeepL's HTTP API as both source and target languages.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -117,7 +117,7 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "deepl"
-version = "0.7.3"
+version = "0.8.0"
 dependencies = [
  "docx-rs",
  "paste",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deepl"
-version = "0.7.3"
+version = "0.8.0"
 edition = "2021"
 authors = ["Avimitin <avimitin@gmail.com>"]
 description = "A Rust implementation of the DeepL API"


### PR DESCRIPTION
## Summary
- Bump version from `0.7.3` to `0.8.0`
- Update CHANGELOG with full list of 66 newly added language variants synced from the DeepL API